### PR TITLE
added matrix type, for #26

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -64,6 +64,13 @@ function deriveColumns(columns: any[]):IColumnDesc[] {
         r.type = 'number';
         r.domain = val.range;
         break;
+      case 'matrix':
+        r.type = 'numbers';
+        r.domain = val.range;
+        r.colorRange = val.colorRange;
+        r.dataLength = val.dataLength;
+        r.labels = val.labels;
+        break;
       default:
         r.type = 'string';
         break;


### PR DESCRIPTION
Closes #26 

Related PR: https://github.com/phovea/phovea_importer/pull/82

Added support for importing matrix columns. The values of a matrix column are displayed as column of type numbers.

![grafik](https://user-images.githubusercontent.com/36196885/37027980-3e09e0d0-2133-11e8-8811-22540fcdb11e.png)
